### PR TITLE
Refactor context

### DIFF
--- a/components/Form/MyInfoForm.tsx
+++ b/components/Form/MyInfoForm.tsx
@@ -1,12 +1,12 @@
-import { ChangeEvent, FormEvent, useCallback, useContext } from 'react';
+import { ChangeEvent, FormEvent, useCallback } from 'react';
 import { useMutation } from 'react-query';
 
-import { LoginContext, LoginContextType } from '@/pages/_app';
 import { Button } from '@/components/Button';
 import { TextInput, TextInputProps } from '@/components/Input';
 import memberService from '@/services/member';
 
 import styles from './MyInfoForm.module.scss';
+import { useLoginContext } from '@/context/Login';
 
 const MyInfoFormItem = ({
   name,
@@ -40,7 +40,7 @@ type MyInfoFormProps = {
 };
 
 const MyInfoForm = ({ form, onChange }: MyInfoFormProps) => {
-  const { userInfo } = useContext(LoginContext) as LoginContextType;
+  const { userInfo } = useLoginContext();
   const { memberId, name, nickname, email } = form;
   const { id } = userInfo;
 

--- a/components/Form/MyPictureURLForm.tsx
+++ b/components/Form/MyPictureURLForm.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image';
-import { ChangeEvent, FormEvent, useCallback, useContext } from 'react';
+import { ChangeEvent, FormEvent, useCallback } from 'react';
 import { useMutation } from 'react-query';
 
-import { LoginContext, LoginContextType } from '@/pages/_app';
+import { useLoginContext } from '@/context/Login';
 import { FileInput } from '@/components/Input';
 import { Button } from '@/components/Button';
 import memberService from '@/services/member';
@@ -20,7 +20,7 @@ const MyPictureURLForm = ({
   pictureURL,
   onChange,
 }: MyPictureURLFormProps) => {
-  const { userInfo } = useContext(LoginContext) as LoginContextType;
+  const { userInfo } = useLoginContext();
   const { id } = userInfo;
 
   const { mutate, isLoading } = useMutation(memberService.updatePicture, {

--- a/components/Form/SearchForm.tsx
+++ b/components/Form/SearchForm.tsx
@@ -1,44 +1,20 @@
 import { FormEvent, memo } from 'react';
-import { useRouter } from 'next/router';
-import useFormChange from '@/hooks/useFormChange';
 import Select from '../Select';
 import { SearchInput } from '../Input';
 import { RiSearchLine } from 'react-icons/ri';
 
 import styles from './SearchForm.module.scss';
+import { useFindMatePostSearchContext } from '@/context/FindMatePost';
 
 const SearchForm = () => {
-  const searchCategory = [
-    { value: 'title', description: '제목' },
-    { value: 'game', description: '게임' },
-    { value: 'hashtag', description: '태그' },
-    { value: 'contents', description: '내용' },
-  ];
+  const { searchCategory, form, onChange, handleSearch } =
+    useFindMatePostSearchContext();
 
-  const router = useRouter();
-  const [form, onChange] = useFormChange({
-    q: '',
-    category: searchCategory[0].value,
-  });
   const { q, category } = form;
-
-  const handleSearchRouter = () => {
-    if (q) {
-      router.push({
-        pathname: '/search',
-        query: {
-          category,
-          q,
-        },
-      });
-      return;
-    }
-    router.push('/');
-  };
 
   const onSubmit = (e: FormEvent) => {
     e.preventDefault();
-    handleSearchRouter();
+    handleSearch();
   };
 
   return (
@@ -57,7 +33,7 @@ const SearchForm = () => {
           value={q}
           onChange={onChange}
         />
-        <div className={styles.icon} onClick={handleSearchRouter}>
+        <div className={styles.icon} onClick={handleSearch}>
           <RiSearchLine />
         </div>
       </div>

--- a/components/Layout/GridLayout.module.scss
+++ b/components/Layout/GridLayout.module.scss
@@ -4,9 +4,10 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 16px;
-  width: 100%;
   margin: auto;
   padding-top: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 @include tablet {
@@ -19,6 +20,8 @@
   .grid {
     grid-template-columns: repeat(4, 1fr);
     max-width: $desktop-layout;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/components/Layout/Layout.module.scss
+++ b/components/Layout/Layout.module.scss
@@ -2,9 +2,10 @@
 
 .layout {
   display: flex;
-  width: 100%;
   margin: auto;
   padding-top: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 @include tablet {
@@ -16,6 +17,8 @@
 @include desktop {
   .layout {
     max-width: $desktop-layout;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/components/Layout/MobileOnlyLayout.module.scss
+++ b/components/Layout/MobileOnlyLayout.module.scss
@@ -2,6 +2,8 @@
 
 .layout {
   display: block;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 @include tablet {

--- a/components/Layout/SplitLayout.module.scss
+++ b/components/Layout/SplitLayout.module.scss
@@ -4,9 +4,10 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
-  width: 100%;
   margin: auto;
   padding-top: 1rem;
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .left {
@@ -26,6 +27,8 @@
 @include desktop {
   .layout {
     max-width: $desktop-layout;
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 

--- a/components/LoginMenu.tsx
+++ b/components/LoginMenu.tsx
@@ -1,17 +1,15 @@
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useContext, useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 
 import useToggle from '@/hooks/useToggle';
 import { Button } from '@/components/Button';
-import { LoginContext, LoginContextType } from '@/pages/_app';
+import { useLoginContext } from '@/context/Login';
 import MyMenu from './MyMenu';
 import { MyMenuDropdown } from './Dropdown';
 
 const LoginMenu = () => {
-  const { isLogin, toggleIsLogin, setUserInfo } = useContext(
-    LoginContext,
-  ) as LoginContextType;
+  const { isLogin, setUserInfoLogout } = useLoginContext();
   const [menuOpen, toggleMenuOpen] = useToggle();
   const router = useRouter();
 
@@ -20,9 +18,8 @@ const LoginMenu = () => {
   }, [menuOpen]);
 
   const onLogout = useCallback(() => {
-    toggleIsLogin(false);
-    setUserInfo({ id: '' });
-  }, [toggleIsLogin]);
+    setUserInfoLogout();
+  }, [setUserInfoLogout]);
 
   useEffect(() => {
     if (menuOpen) handleMenuClose();

--- a/components/LoginMenu.tsx
+++ b/components/LoginMenu.tsx
@@ -15,15 +15,15 @@ const LoginMenu = () => {
 
   const handleMenuClose = useCallback(() => {
     if (menuOpen) toggleMenuOpen(false);
-  }, [menuOpen]);
+  }, [menuOpen, toggleMenuOpen]);
 
   const onLogout = useCallback(() => {
     setUserInfoLogout();
   }, [setUserInfoLogout]);
 
   useEffect(() => {
-    if (menuOpen) handleMenuClose();
-  }, [router]);
+    toggleMenuOpen(false);
+  }, [router, toggleMenuOpen]);
 
   const menuItems = [
     {

--- a/components/Main.module.scss
+++ b/components/Main.module.scss
@@ -1,13 +1,11 @@
 @import '@/styles/media.scss';
 
 .main {
-  padding: 0 1rem;
   margin-top: 0.5rem;
 }
 
 @include desktop {
   .main {
-    padding: 0;
     margin-top: 1rem;
   }
 }

--- a/components/Select/index.tsx
+++ b/components/Select/index.tsx
@@ -1,12 +1,12 @@
 import { ChangeEvent } from 'react';
 import styles from './index.module.scss';
 
-export type Option = { value: string; description: string };
+export type SelectOption = { value: string; description: string };
 
 type SelectProps = {
   name: string;
   value: string;
-  option: Option[];
+  option: SelectOption[];
   onChange: (e: ChangeEvent<HTMLSelectElement>) => void;
 };
 

--- a/context/CombineProvider.tsx
+++ b/context/CombineProvider.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable react/display-name */
+import { ReactNode } from 'react';
+
+type Provider = ({ children }: { children: ReactNode }) => JSX.Element;
+
+const CombineProvider = (components: Provider[]) =>
+  components.reduce(
+    (AccProvider, CurProvider) =>
+      ({ children }: { children: ReactNode }) =>
+        (
+          <AccProvider>
+            <CurProvider>{children}</CurProvider>
+          </AccProvider>
+        ),
+    ({ children }: { children: ReactNode }) => <>{children}</>,
+  );
+
+export default CombineProvider;

--- a/context/FindMatePost/Search.tsx
+++ b/context/FindMatePost/Search.tsx
@@ -1,0 +1,65 @@
+import { ChangeEvent, createContext, ReactNode } from 'react';
+import { useRouter } from 'next/router';
+
+import useFormChange from '@/hooks/useFormChange';
+import { SelectOption } from '@/components/Select';
+
+type SearchForm = {
+  q: string;
+  category: string;
+};
+
+type SearchContextType = {
+  searchCategory: SelectOption[];
+  form: SearchForm;
+  onChange: (e: ChangeEvent<HTMLInputElement | HTMLSelectElement>) => void;
+  handleSearch: () => void;
+};
+
+export const SearchContext = createContext<SearchContextType | null>(null);
+
+const Search = ({ children }: { children: ReactNode }) => {
+  const searchCategory = [
+    { value: 'title', description: '제목' },
+    { value: 'game', description: '게임' },
+    { value: 'hashtag', description: '태그' },
+    { value: 'contents', description: '내용' },
+  ];
+
+  const router = useRouter();
+  const [form, onChange] = useFormChange({
+    q: '',
+    category: searchCategory[0].value,
+  });
+
+  const { q, category } = form;
+
+  const handleSearch = () => {
+    if (q) {
+      router.push({
+        pathname: '/search',
+        query: {
+          category,
+          q,
+        },
+      });
+      return;
+    }
+    router.push('/');
+  };
+
+  return (
+    <SearchContext.Provider
+      value={{
+        searchCategory,
+        form,
+        onChange,
+        handleSearch,
+      }}
+    >
+      {children}
+    </SearchContext.Provider>
+  );
+};
+
+export default Search;

--- a/context/FindMatePost/index.tsx
+++ b/context/FindMatePost/index.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import SearchProvider, { SearchContext } from './Search';
+
+const useFindMatePostSearchContext = () => {
+  const state = useContext(SearchContext);
+  if (!state) throw new Error('Cannot find Provider');
+  return state;
+};
+
+export { useFindMatePostSearchContext };
+export default SearchProvider;

--- a/context/Login/Context.tsx
+++ b/context/Login/Context.tsx
@@ -1,0 +1,55 @@
+import { createContext, ReactNode, useEffect } from 'react';
+
+import useToggle from '@/hooks/useToggle';
+import useLocalStorage from '@/hooks/useLocalStorage';
+
+type DefaultUserInfo = {
+  id: '';
+};
+
+type LoginContextType = {
+  isLogin: boolean;
+  userInfo: Member | DefaultUserInfo;
+  setUserInfoData: (data: Member) => void;
+  setUserInfoLogout: () => void;
+};
+
+export const LoginContext = createContext<LoginContextType | null>(null);
+
+const LoginProvider = ({ children }: { children: ReactNode }) => {
+  const [isLogin, toggleIsLogin] = useToggle();
+  const [userInfo, setUserInfo] = useLocalStorage<Member | DefaultUserInfo>(
+    'userInfo',
+    { id: '' },
+  );
+
+  const setUserInfoData = (data: Member) => {
+    toggleIsLogin(true);
+    setUserInfo(data);
+  };
+
+  const setUserInfoLogout = () => {
+    toggleIsLogin(false);
+    setUserInfo({ id: '' });
+  };
+
+  useEffect(() => {
+    if (
+      typeof userInfo === 'object' &&
+      !Array.isArray(userInfo) &&
+      userInfo !== null
+    ) {
+      toggleIsLogin(true);
+    }
+  }, []);
+
+  return (
+    <LoginContext.Provider
+      value={{ isLogin, userInfo, setUserInfoData, setUserInfoLogout }}
+    >
+      {children}
+    </LoginContext.Provider>
+  );
+};
+
+export default LoginProvider;

--- a/context/Login/Login.tsx
+++ b/context/Login/Login.tsx
@@ -35,10 +35,9 @@ const Login = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (
-      !isLogin &&
       typeof userInfo === 'object' &&
       !Array.isArray(userInfo) &&
-      userInfo !== null
+      userInfo?.id
     ) {
       toggleIsLogin(true);
     }

--- a/context/Login/Login.tsx
+++ b/context/Login/Login.tsx
@@ -16,7 +16,7 @@ type LoginContextType = {
 
 export const LoginContext = createContext<LoginContextType | null>(null);
 
-const LoginProvider = ({ children }: { children: ReactNode }) => {
+const Login = ({ children }: { children: ReactNode }) => {
   const [isLogin, toggleIsLogin] = useToggle();
   const [userInfo, setUserInfo] = useLocalStorage<Member | DefaultUserInfo>(
     'userInfo',
@@ -35,13 +35,14 @@ const LoginProvider = ({ children }: { children: ReactNode }) => {
 
   useEffect(() => {
     if (
+      !isLogin &&
       typeof userInfo === 'object' &&
       !Array.isArray(userInfo) &&
       userInfo !== null
     ) {
       toggleIsLogin(true);
     }
-  }, []);
+  }, [isLogin, toggleIsLogin, userInfo]);
 
   return (
     <LoginContext.Provider
@@ -52,4 +53,4 @@ const LoginProvider = ({ children }: { children: ReactNode }) => {
   );
 };
 
-export default LoginProvider;
+export default Login;

--- a/context/Login/index.tsx
+++ b/context/Login/index.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+import LoginProvider, { LoginContext } from './Context';
+
+const useLoginContext = () => {
+  const state = useContext(LoginContext);
+  if (!state) throw new Error('Cannot find Provider');
+  return state;
+};
+
+export { useLoginContext };
+export default LoginProvider;

--- a/context/Login/index.tsx
+++ b/context/Login/index.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import LoginProvider, { LoginContext } from './Context';
+import LoginProvider, { LoginContext } from './Login';
 
 const useLoginContext = () => {
   const state = useContext(LoginContext);

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -1,6 +1,7 @@
 import CombineProvider from './CombineProvider';
-import LoginProvider from './Login';
+import SearchProvider from './FindMatePost';
+import Login from './Login';
 
-const providers = [LoginProvider];
+const providers = [Login, SearchProvider];
 
 export const ContextProvider = CombineProvider(providers);

--- a/context/index.tsx
+++ b/context/index.tsx
@@ -1,0 +1,6 @@
+import CombineProvider from './CombineProvider';
+import LoginProvider from './Login';
+
+const providers = [LoginProvider];
+
+export const ContextProvider = CombineProvider(providers);

--- a/layout/LoginLayout.tsx
+++ b/layout/LoginLayout.tsx
@@ -1,21 +1,17 @@
 import Link from 'next/link';
-import { useContext } from 'react';
 import { useMutation } from 'react-query';
 
 import { Layout } from '@/components/Layout';
 import { Button } from '@/components/Button';
-import { LoginContext, LoginContextType } from '@/pages/_app';
+import { useLoginContext } from '@/context/Login';
 import memberService from '@/services/member';
 
 const LoginLayout = () => {
-  const { toggleIsLogin, setUserInfo } = useContext(
-    LoginContext,
-  ) as LoginContextType;
+  const { setUserInfoData } = useLoginContext();
 
   const { mutate, isLoading } = useMutation(memberService.login, {
     onSuccess: data => {
-      toggleIsLogin(true);
-      setUserInfo(data);
+      setUserInfoData(data);
     },
   });
 

--- a/layout/MyInfoLayout.tsx
+++ b/layout/MyInfoLayout.tsx
@@ -1,8 +1,8 @@
 import { AxiosError } from 'axios';
-import { useCallback, useContext, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 
-import { LoginContext, LoginContextType } from '@/pages/_app';
+import { useLoginContext } from '@/context/Login';
 import useFormChange from '@/hooks/useFormChange';
 import memberService from '@/services/member';
 import { QueryKeys } from '@/libs/client';
@@ -13,7 +13,7 @@ import { MyInfoForm, MyPictureURLForm } from '@/components/Form';
 import MyInfoMenu from '@/components/Menu/MyInfoMenu';
 
 const MyInfoLayout = () => {
-  const { userInfo } = useContext(LoginContext) as LoginContextType;
+  const { userInfo } = useLoginContext();
   const [memberId, setMemberId] = useState('');
   const [pictureURL, setPictureURL] = useState('');
   const [form, onChange, setForm] = useFormChange({

--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
         '@/hooks': path.resolve(__dirname, 'src/hooks'),
         '@/services': path.resolve(__dirname, 'src/services'),
         '@/data': path.resolve(__dirname, 'src/data'),
-        '@/utils': path.resolve(__dirname, 'src/utils'),
+        '@/context': path.resolve(__dirname, 'src/context'),
       },
       ...config.resolve,
     };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,55 +1,23 @@
 import type { AppProps } from 'next/app';
-import { createContext, useEffect } from 'react';
 import { QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 
 import HeaderLayout from '@/layout/HeaderLayout';
-import useToggle from '@/hooks/useToggle';
-import useLocalStorage from '@/hooks/useLocalStorage';
 import { getClient } from '@/libs/client';
 
 import '@/styles/globals.scss';
-
-type DefaultUserInfo = {
-  id: '';
-};
-
-export type LoginContextType = {
-  isLogin: boolean;
-  toggleIsLogin: (state?: boolean) => void;
-  userInfo: Member | DefaultUserInfo;
-  setUserInfo: (data: Member | DefaultUserInfo) => void;
-};
-
-export const LoginContext = createContext<LoginContextType | null>(null);
+import { ContextProvider } from 'context';
 
 function MyApp({ Component, pageProps }: AppProps) {
   const queryClient = getClient();
-  const [isLogin, toggleIsLogin] = useToggle();
-  const [userInfo, setUserInfo] = useLocalStorage<Member | DefaultUserInfo>(
-    'userInfo',
-    { id: '' },
-  );
-
-  useEffect(() => {
-    if (
-      typeof userInfo === 'object' &&
-      !Array.isArray(userInfo) &&
-      userInfo !== null
-    ) {
-      toggleIsLogin(true);
-    }
-  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>
-      <LoginContext.Provider
-        value={{ isLogin, toggleIsLogin, userInfo, setUserInfo }}
-      >
+      <ContextProvider>
         <HeaderLayout />
         <Component {...pageProps} />
         <ReactQueryDevtools initialIsOpen={false} />
-      </LoginContext.Provider>
+      </ContextProvider>
     </QueryClientProvider>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
       "@/hooks/*": ["hooks/*"],
       "@/services/*": ["services/*"],
       "@/data/*": ["data/*"],
-      "@/utils/*": ["utils/*"],
+      "@/context/*": ["context/*"],
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65995108/179235240-b8545b58-41e6-4ca5-9c1f-418b48c51418.png)
![image](https://user-images.githubusercontent.com/65995108/179235263-39148069-4b81-4d98-a98e-aa059c659351.png)
Context 를 분리하여 global state 를 관리합니다. Login, Search 부분
원래는 모바일 환경의 검색과 헤더의 검색이 따로 돌았는데 이제 하나의 state 를 사용합니다.
